### PR TITLE
Fix typo item "unqiue"

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -74,7 +74,7 @@ RegisterNetEvent('qb-houserobbery:server:searchCabin', function(cabin, house)
                     Player.Functions.AddItem(randomItem, 1)
                     TriggerClientEvent('inventory:client:ItemBox', src, itemInfo, "add")
             else
-                if not itemInfo["unqiue"] then
+                if not itemInfo["unique"] then
                     local itemAmount = math.random(1, 3)
                     if randomItem == "plastic" then
                         itemAmount = math.random(15, 30)


### PR DESCRIPTION
Typo could cause unknown effects as unique and nonunique items could be given randomly.